### PR TITLE
Alter the ARIA label to include the format suggestion

### DIFF
--- a/jquery.datetextentry.js
+++ b/jquery.datetextentry.js
@@ -508,7 +508,7 @@
         this.empty = true;
         this.$input = $('<input type="text" value="" />')
             .addClass( 'jq-dte-' + this.name )
-            .attr('aria-label', dte.options['field_tip_text_' + this.name])
+            .attr('aria-label', this.tip_text + " (" + this.hint_text + ")" )
             .focus( $.proxy(input, 'focus') )
             .blur(  $.proxy(input, 'blur' ) )
             .keydown( function(e) { setTimeout(function () { input.keydown(e); }, 2) } )

--- a/test/datetextentry.js
+++ b/test/datetextentry.js
@@ -104,8 +104,8 @@
             expect( $dd.is('.jq-dte-day') ).toBe(true);
         });
 
-        it("has 'aria-label'='Day'", function() {
-            expect( $dd.attr('aria-label') ).toBe('Day');
+        it("has 'aria-label'='Day (DD)'", function() {
+            expect( $dd.attr('aria-label') ).toBe('Day (DD)');
         });
 
         runs(function() {
@@ -154,8 +154,8 @@
             expect( $mm.is('.jq-dte-month') ).toBe(true);
         });
 
-        it("has 'aria-label'='Month'", function() {
-            expect( $mm.attr('aria-label') ).toBe('Month');
+        it("has 'aria-label'='Month (MM)'", function() {
+            expect( $mm.attr('aria-label') ).toBe('Month (MM)');
         });
 
         runs(function() {
@@ -204,8 +204,8 @@
             expect( $yyyy.is('.jq-dte-year') ).toBe(true);
         });
 
-        it("has 'aria-label'='Year'", function() {
-            expect( $yyyy.attr('aria-label') ).toBe('Year');
+        it("has 'aria-label'='Year (YYYY)'", function() {
+            expect( $yyyy.attr('aria-label') ).toBe('Year (YYYY)');
         });
 
         runs(function() {


### PR DESCRIPTION
Results of an accessibility review on a project using this library included a suggestion that the labels of these fields should include both a field name and a suggestion for the format thereof.