### PR TITLE
Add inputmode="numeric" to date input fields.

### DIFF
--- a/jquery.datetextentry.js
+++ b/jquery.datetextentry.js
@@ -558,6 +558,7 @@
         this.$input = $('<input type="text" value="" />')
             .addClass('jq-dte-' + this.name)
             .attr('aria-label', this.tip_text + ' (' + this.hint_text + ')')
+            .attr('inputmode', 'numeric')
             .focus($.proxy(input, 'focus'))
             .blur($.proxy(input, 'blur'))
             .keydown(function (e) { setTimeout(function () { input.keydown(e); }, 2); })


### PR DESCRIPTION
The default virtual keyboard on some mobile phones does not include
numbers making entering dates slightly tedious. Adding the inputmode
attribute allows mobile browsers that support it to default to an
appropriate virtual keyboard.